### PR TITLE
Option objective fn

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+For this branch, I want to make so that user can input their own convex objective
+function. Here is my thought about how to do it (main changes would be in
+`information_matching/convex_optimization.py`):
+* Remove `l1norm_obj` argument.
+  Replace it with `obj_fn` (callable) and `obj_fn_kwargs` (dict) arguments
+  - We need to check if the `obj_fn` is a cvxpy function.
+* Change the `_objective_fn` method, probably like
+  ```bash
+  def _objective_fn(self):
+      scaled_weights = cp.multiply(self.wm, self.scale_weights.reshape((-1, 1)))
+	  return self.obj_fn(scaled_weights, **self.obj_fn_kwargs)
+  ```
+* Create a unit test.
+  Probably we can just put the test in `tests/test_convexopt.py`.
+  For example, if we use l2-norm objective function instead of l1-norm, we would get many
+  nonzero weights.

--- a/tests/test_convexopt.py
+++ b/tests/test_convexopt.py
@@ -1,4 +1,6 @@
+import pytest
 import numpy as np
+import cvxpy as cp
 
 from information_matching import ConvexOpt
 
@@ -9,64 +11,111 @@ np.random.seed(1)
 scale = np.random.uniform(0, 10)
 # Target
 fim_target = np.eye(3) * scale
-fim_target_weighted = {"fim": fim_target, "fim_scale": 1 / 3}
-# Configurations
-fim_config_1 = np.eye(3)
-fim_config_2 = np.diag(np.zeros(3))
-fim_config_3 = np.diag([1, 2, 3])
-fim_configs = {"1": fim_config_1, "2": fim_config_2}
-fim_configs_weighted = {"1": {"fim": fim_config_1, "fim_scale": 3}, "2": fim_config_2}
-fim_configs_extended = {"1": fim_config_1, "2": fim_config_2, "3": fim_config_3}
+# Candidates
+fim_candidate_1 = np.eye(3)
+fim_candidate_2 = np.diag(np.zeros(3))
+fim_candidate_3 = np.diag([1, 2, 3])
+fim_candidates = {"1": fim_candidate_1, "2": fim_candidate_2}
 
 # Solve
-cvxopt = ConvexOpt(fim_target, fim_configs)
+cvxopt = ConvexOpt(fim_target, fim_candidates)
 cvxopt.solve()
-# Alternative cvxopt to test the FIM scaling
-cvxopt_alt = ConvexOpt(fim_target_weighted, fim_configs_weighted)
 
 
 def test_default_scale():
+    """Test if the default scaling factor is set correctly. The values should all be 1.0."""
     assert cvxopt.scale_qoi == 1.0, "Default scale_qoi fail"
     assert all(cvxopt.scale_conf == np.ones(2)), "Default scale_conf fail"
     assert all(cvxopt.scale_weights == np.ones(2)), "Default scale_weights fail"
 
 
 def test_scaling():
+    """Test if FIM scaling is implemented correctly."""
+    fim_target_weighted = {"fim": fim_target, "fim_scale": 1 / 3}
+    fim_candidates_weighted = {
+        "1": {"fim": fim_candidate_1, "fim_scale": 3},
+        "2": fim_candidate_2,
+    }
+    cvxopt = ConvexOpt(fim_target_weighted, fim_candidates_weighted)
     # FIM target scaling
-    assert cvxopt_alt.scale_qoi == 1 / 3, "Retrieving target FIM scaling fail"
+    assert cvxopt.scale_qoi == 1 / 3, "Retrieving target FIM scaling fail"
     assert np.allclose(
-        cvxopt_alt.fim_qoi_vec, fim_target.flatten() / 3
+        cvxopt.fim_qoi_vec, fim_target.flatten() / 3
     ), "Target FIM scaling fail"
-    # FIM configs scaling
-    assert all(cvxopt_alt.scale_conf == [3, 1]), "Retrieving config FIM scaling fail"
+    # FIM candidates scaling
+    assert all(cvxopt.scale_conf == [3, 1]), "Retrieving candidate FIM scaling fail"
     assert np.allclose(
-        cvxopt_alt.fim_configs_vec[0], fim_config_1.flatten() * 3
-    ), "Config FIM scaling fail"
+        cvxopt.fim_configs_vec[0], fim_candidate_1.flatten() * 3
+    ), "Candidate FIM scaling fail"
 
 
 def test_result_keys():
+    """Check the keys of the .result property."""
     for key in ["status", "wm", "dual_wm", "value", "rel_error", "violation"]:
         assert key in cvxopt.result, f"{key} not in result"
 
 
 def test_optimal_result():
-    opt_config = cvxopt.get_config_weights(1e-6, 1e-6)
-    # For this simple case, we know which configuration is optimal and its optimal weight
-    assert list(opt_config)[0] == "1", "Wrong optimal config"
+    """Check the values of the optimal weights.
+
+    Since the target FIM is just a scalar multiple of one of the candidate FIM, then the
+    optimal weight should just be the same scaling factor.
+    """
+    opt_candidate = cvxopt.get_config_weights(1e-6, 1e-6)
+    # For this simple case, we know which candidate is optimal and its optimal weight
+    assert list(opt_candidate)[0] == "1", "Wrong optimal candidate"
     assert np.isclose(
-        opt_config["1"], scale, rtol=1e-4, atol=1e-4
+        opt_candidate["1"], scale, rtol=1e-4, atol=1e-4
     ), "Wrong optimal weight"
 
 
 def test_weight_upper_bound():
+    """Test if the additional constraint of weight upper bound is implemented correctly.
+
+    If it is implemented correctly, then the optimal weights should NOT exceed the upper
+    bound.
+    """
+    fim_candidates = {"1": fim_candidate_1, "2": fim_candidate_2, "3": fim_candidate_3}
     w_ub = 3  # Upper bound for the optimal weights
-    cvxopt = ConvexOpt(fim_target, fim_configs_extended, weight_upper_bound=w_ub)
+    cvxopt = ConvexOpt(fim_target, fim_candidates, weight_upper_bound=w_ub)
     cvxopt.solve()
-    opt_config = cvxopt.get_config_weights(1e-6, 1e-6)
+    opt_candidate = cvxopt.get_config_weights(1e-6, 1e-6)
     # This optimization should be successful, and the weights should be lower than the
     # upper bound
-    for val in opt_config.values():
+    for val in opt_candidate.values():
         assert val <= w_ub, "Optimal weight exceeds upper bound"
+
+
+def test_different_objective_fn():
+    """Test if the option to specify objective function is implemented correctly.
+
+    In theory, if we use l2-norm objective function, then if we have a redundant data,
+    the optimal weights of the redundant data should be the same. In contrast, the
+    weights of the redundant data if we use l1-norm objective function don't need to be
+    the same.
+    """
+    # Add a redundant data
+    fim_candidates = {
+        "1": fim_candidate_1,
+        "2": fim_candidate_2,
+        "3": fim_candidate_3,
+        "4": fim_candidate_1,
+    }
+    # Test if an exception is raised if the objective function is not convex
+    with pytest.raises(ValueError):
+        cvxopt = ConvexOpt(fim_target, fim_candidates, obj_fn=cp.sqrt)
+    # Test the optimization result
+    cvxopt = ConvexOpt(fim_target, fim_candidates, obj_fn=cp.norm2)
+    cvxopt.solve()
+    # First, the optimal result should NOT select candidate 2, which has zero matrix
+    # as the FIM
+    assert "2" not in cvxopt.get_config_weights(), "Failed: Candidate 2 selected"
+    # Second, the optimal weights of the redundant data (first and last data) should be
+    # the same
+    weights = list(cvxopt.get_config_weights().values())
+    assert np.isclose(
+        weights[0], weights[-1], atol=1e-6, rtol=1e-6
+    ), "Failed: Redundant data weights should have the same weights"
 
 
 if __name__ == "__main__":
@@ -75,3 +124,4 @@ if __name__ == "__main__":
     test_result_keys()
     test_optimal_result()
     test_weight_upper_bound()
+    test_different_objective_fn()


### PR DESCRIPTION
Add an additional option to specify objective function, instead of just using `l1norm_obj`, which limits the options of the objective function.
With this version, user should be able to use any convex function as objective.

**Motivation:**<br>
Using l1-norm of weights encourage sparse solution. But, maybe this is not what we want. So, we might consider using l2-norm instead. Additionally, with l2-norm objective, the weight values should be more uniform compared to if we use l1-norm objective.